### PR TITLE
Update X509_VERIFY_PARAM_set_flags.pod

### DIFF
--- a/doc/man3/X509_VERIFY_PARAM_set_flags.pod
+++ b/doc/man3/X509_VERIFY_PARAM_set_flags.pod
@@ -255,8 +255,8 @@ ored together.
 B<X509_V_FLAG_CRL_CHECK> enables CRL checking for the certificate chain leaf
 certificate. An error occurs if a suitable CRL cannot be found.
 
-B<X509_V_FLAG_CRL_CHECK_ALL> enables CRL checking for the entire certificate
-chain.
+B<X509_V_FLAG_CRL_CHECK_ALL> expands CRL checking to the entire certificate
+chain if B<X509_V_FLAG_CRL_CHECK> has also been enabled, and is otherwise ignored.
 
 B<X509_V_FLAG_IGNORE_CRITICAL> disables critical extension checking. By default
 any unhandled critical extensions in certificates or (if checked) CRLs result


### PR DESCRIPTION
Change description of B<X509_V_FLAG_CRL_CHECK_ALL> to reflect its inability to function without B<X509_V_FLAG_CRL_CHECK> being enabled as well. Fixes #27056

<!--
Thank you for your pull request. Please review these requirements:

Contributors guide: https://github.com/openssl/openssl/blob/master/CONTRIBUTING.md

Other than that, provide a description above this comment if there isn't one already

If this fixes a GitHub issue, make sure to have a line saying 'Fixes #XXXX' (without quotes) in the commit message.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
- [x] documentation is added or updated
- [ ] tests are added or updated
